### PR TITLE
Add an options object to turn on/off debugging (closes #2)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,12 +27,34 @@ gulp.task('default', function () {
 });
 ```
 
+## Debugging
+
+Debugging output can be turned on by passing in an options object with `debug: true`.
+
+```js
+var gulp = require('gulp');
+var forEach = require('gulp-forEach');
+
+gulp.task('default', function () {
+  return gulp.src('src/*.js')
+    .pipe(forEach({
+        // Turn on debugging output
+        debug: true
+      }, function(stream, file){
+      return stream
+        .pipe(doSomethingWithEachFileIndividually())
+        .pipe(concat(file.name));
+    }))
+    .pipe(gulp.dest('dist'));
+});
+```
+
 
 ## API
 
-The forEach method takes one argument, a function. This function is called once for each file piped to `forEach` and is passed a stream as its first argument and the file as its second argument. The stream contains only one file.
+The forEach method accepts an optional options object and a function. This function is called once for each file piped to `forEach` and is passed a stream as its first argument and the file as its second argument. The stream contains only one file.
 
-You can optionally return a stream from the `forEach` function. All the streams returned from `forEach` will be combined and their contents will be emited by `forEach`. 
+You can optionally return a stream from the `forEach` function. All the streams returned from `forEach` will be combined and their contents will be emited by `forEach`.
 
 ## License
 


### PR DESCRIPTION
The console.logs in the plugin can be very useful when setting up gulp
tasks, but they're a huge annoyance after that point. This change allows
these logs to be turned on or off with a settings object that can also
be used for any other customization options needed in the future.
